### PR TITLE
Add support for building Linux binaries

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,17 +9,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
     - name: Install Snapcraft
       uses: samuelmeuli/action-snapcraft@v1
-    
+
     - name: Use Node.js 20.x
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: 20.x
+
+    - name: Install Linux build dependencies
+      run: sudo apt-get update && sudo apt-get install -y rpm
 
     - name: install dependencies
       run: npm i
@@ -30,10 +33,20 @@ jobs:
         SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       run: npm run build:linux -- --publish never
 
-    - name: publish amd64
+    - name: publish snap amd64
       uses: snapcore/action-publish@v1
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_EXPORT }}
       with:
         snap: "${{ github.workspace }}/dist/Raindrop-amd64.snap"
         release: stable
+
+    - name: Upload Linux artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: linux-builds
+        path: |
+          dist/*.deb
+          dist/*.rpm
+          dist/*.AppImage
+          dist/*.snap

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,7 +38,7 @@ jobs:
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_EXPORT }}
       with:
-        snap: "${{ github.workspace }}/dist/Raindrop-amd64.snap"
+        snap: "${{ github.workspace }}/dist/Raindrop-x64.snap"
         release: stable
 
     - name: Upload Linux artifacts

--- a/build/config.js
+++ b/build/config.js
@@ -91,7 +91,24 @@ exports.default = ()=>({
         executableName: 'raindrop',
         icon: 'build/linux',
         category: 'GNOME;GTK;Network;Education;Science',
-        target: ['snap'],
+        target: [
+            {
+                target: 'deb',
+                arch: ['x64', 'arm64']
+            },
+            {
+                target: 'rpm',
+                arch: ['x64', 'arm64']
+            },
+            {
+                target: 'AppImage',
+                arch: ['x64', 'arm64']
+            },
+            {
+                target: 'snap',
+                arch: ['x64']
+            }
+        ],
         desktop: {
             entry: {
                 StartupWMClass: 'Raindrop.io',
@@ -100,6 +117,15 @@ exports.default = ()=>({
         }
     },
 
+    deb: {
+        artifactName: 'Raindrop-${arch}.${ext}'
+    },
+    rpm: {
+        artifactName: 'Raindrop-${arch}.${ext}'
+    },
+    appImage: {
+        artifactName: 'Raindrop-${arch}.${ext}'
+    },
     snap: {
         artifactName: 'Raindrop-${arch}.${ext}'
     }


### PR DESCRIPTION
This pull request adds support for building Linux binaries beyond just snap packages.

- New workflow runs will build `deb`s, `rpm`s and `AppImage`s alongside `snap` packages.
- New runs will also build binaries for both x64 and arm64 platforms for all packages besides snap.
- `actions/checkout` and `actions/setup-node` were also updated to use the latest v4 versions.
- Generated artifacts are now uploaded for easy access.

All generated builds were tested and confirmed working, all showing name and icon on the app list and with login functionality also working (as well as the app itself).

**CI/CD workflow updates:**

* Updated `actions/checkout` and `actions/setup-node` in `.github/workflows/linux.yml` to use the latest v4 versions for improved performance and support.
* Added a step to install Linux build dependencies (`rpm` package) in the workflow.

**Linux packaging enhancements:**

* Modified the build configuration in `build/config.js` to support building for multiple Linux targets: `deb`, `rpm`, `AppImage` (all for x64 and arm64), and `snap` (x64 only).
* Configured each package type (`deb`, `rpm`, `appImage`, `snap`) to use a consistent artifact naming convention: `Raindrop-${arch}.${ext}`.

**Artifact management:**

* Updated the workflow to upload all generated Linux artifacts (`.deb`, `.rpm`, `.AppImage`, `.snap`) after the build for easy access.